### PR TITLE
fix: allow to override config file name with -X ld flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This command creates the following structure:
 
 ```
 your_dir
-├── adrgen.config.yml
+├── adrgen.config.yaml
 └── docs
     └── adrs
         └── adr_template.md
@@ -63,7 +63,7 @@ As the result, we can see
 * A markdown template is created in the desired directory
 
 
-The adrgen.config.yml config file will be used by other commands in order to know how to operate with the ADR files.
+The adrgen.config.yaml config file will be used by other commands in order to know how to operate with the ADR files.
 
 It will include the following configuration keys:
 

--- a/features/1. init_the_directory_and_config.feature
+++ b/features/1. init_the_directory_and_config.feature
@@ -22,7 +22,7 @@ Feature: init the directory and config
 
     Examples:
 
-    | target_directory       | template_created                | config_file         |
-    | ./target               | ./target/adr_template.md        | ./adrgen.config.yml |
-    | ./target/level         | ./target/level/adr_template.md  | ./adrgen.config.yml |
+    | target_directory       | template_created                | config_file          |
+    | ./target               | ./target/adr_template.md        | ./adrgen.config.yaml |
+    | ./target/level         | ./target/level/adr_template.md  | ./adrgen.config.yaml |
 

--- a/internal/_infrastructure/configFileManager.go
+++ b/internal/_infrastructure/configFileManager.go
@@ -26,7 +26,7 @@ func (manager privateConfigFileManager) Persist(configData config.Config) error 
 	viper.Set("supported_statuses", configData.Statuses)
 	viper.Set("default_status", configData.DefaultStatus)
 	viper.Set("id_digit_number", configData.IdDigitNumber)
-	return viper.WriteConfigAs(config.FILENAME + ".yml")
+	return viper.WriteConfigAs(config.FILENAME + "." + config.FORMAT)
 }
 
 func (manager privateConfigFileManager) Read() (config.Config, error) {

--- a/internal/_infrastructure/e2e/steps.go
+++ b/internal/_infrastructure/e2e/steps.go
@@ -254,7 +254,7 @@ template_file: %s
 		row.GetCells()[2].Value,
 	)
 
-	configFile := "adrgen.config.yml"
+	configFile := "adrgen.config.yaml"
 
 	output, err := exec.Command("/bin/sh", "-c", fmt.Sprintf(
 		"cd features/e2e/tests; touch %s; echo \"%s\" > %s",
@@ -283,7 +283,7 @@ template_file: %s
 }
 
 func thereIsNotAnyConfigFile() error {
-	exec.Command("/bin/sh", "-c", "rm features/e2e/tests/adrgen.config.yml").CombinedOutput()
+	exec.Command("/bin/sh", "-c", "rm features/e2e/tests/adrgen.config.yaml").CombinedOutput()
 	directory = ""
 	return nil
 }

--- a/internal/config/root.go
+++ b/internal/config/root.go
@@ -6,7 +6,7 @@ var FILENAME = "adrgen.config"
 
 // FORMAT the configuration format
 //
-const FORMAT = "yaml"
+var FORMAT = "yaml"
 
 // Config the Configuration type with all the supported values
 //

--- a/internal/config/root.go
+++ b/internal/config/root.go
@@ -2,7 +2,7 @@ package config
 
 // FILENAME the name for the config file
 //
-const FILENAME = "adrgen.config"
+var FILENAME = "adrgen.config"
 
 // FORMAT the configuration format
 //

--- a/internal/project/root.go
+++ b/internal/project/root.go
@@ -20,7 +20,7 @@ func InitProject(
 
 	err = configManager.Persist(configData)
 	if err != nil {
-		return fmt.Errorf("error creating config file %s %s", config.FILENAME+".yml", err)
+		return fmt.Errorf("error creating config file %s %s", config.FILENAME + "." + config.FORMAT, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Motivation

`adrgen.config.yml` is very prominent in the top level repository folder estate for an auxiliary tool.

Users may want to change that, for example, to a more subtle `.adrgen.yml`.

# Proposed solution

- Change constant to variable so that people can use `"-X github.com/asiermarques/adrgen/internal/config.FILENAME=.adrgen"`
